### PR TITLE
Changed configmap to daemonset

### DIFF
--- a/doc_source/external-snat.md
+++ b/doc_source/external-snat.md
@@ -13,7 +13,7 @@ SNAT is required for nodes that reside in a public subnet\. To use external SNAT
 
 **To disable SNAT on your worker nodes**
 
-1. Edit the `aws-node` configmap:
+1. Edit the `aws-node` daemonset:
 
    ```
    kubectl edit daemonset -n kube-system aws-node


### PR DESCRIPTION
The environment variables are part of the CNI daemonset.  They're not stored in a configmap.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
